### PR TITLE
Update Dockerfile

### DIFF
--- a/cluster/images/controller-manager/Dockerfile
+++ b/cluster/images/controller-manager/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.20.2
+ARG GOLANG_IMAGE=golang:1.20
 
 # The distroless image on which the CPI manager image is built.
 #
@@ -23,7 +23,7 @@ ARG GOLANG_IMAGE=golang:1.20.2
 # the fully-qualified image can be obtained by entering
 # "gcr.io/distroless/static:latest" in a browser and then copying the
 # fully-qualified image from the web page.
-ARG DISTROLESS_IMAGE=gcr.io/distroless/static-debian11@sha256:a01d47d4036cae5a67a9619e3d06fa14a6811a2247b4da72b4233ece4efebd57
+ARG DISTROLESS_IMAGE=gcr.io/distroless/static-debian11@latest
 
 ################################################################################
 ##                              BUILD STAGE                                   ##


### PR DESCRIPTION
Use floating versions by upstream maintainers to reduce maintenance

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Update base images to latest
```
